### PR TITLE
Fix name generation in Safari

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,9 @@
+/coverage/
 /test/
+.browserslistrc
 .editorconfig
 .eslintrc
 karma.conf.js
+karma.bs.conf.js
 wallaby.js
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.1.1"></a>
+## [0.1.1](https://github.com/bashmish/carehtml/compare/v0.1.0...v0.1.1) (2019-08-22)
+
+
+### Bug Fixes
+
+* generate name correctly in Safari if constructor has no name ([f9af239](https://github.com/bashmish/carehtml/commit/f9af239))
+
+
+
 <a name="0.1.0"></a>
 # 0.1.0 (2018-12-22)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carehtml",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carehtml",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Templates with automatic registration of Custom Elements.",
   "license": "MIT",
   "author": "Mikhail Bashkirov <bashmish@gmail.com>",

--- a/src/transform.js
+++ b/src/transform.js
@@ -29,7 +29,7 @@ function getClassUniqueTag(klass) {
     return tag;
   }
 
-  if (Object.prototype.hasOwnProperty.call(klass, 'name')) {
+  if (Object.prototype.hasOwnProperty.call(klass, 'name') && klass.name) {
     tag = toDashCase(klass.name);
     if (tag.indexOf('-') === -1) {
       tag = `c-${tag}`;


### PR DESCRIPTION
Fixes this behavior:

```
FAILED TESTS:
  transform
    name generator
      ✖ fallbacks to a name "c-%index%" if constructor has no name
        Safari 12.1.2 (Mac OS X 10.14.6)
      expected 'c-' to equal 'c-1'

      + expected - actual

      -c-
      +c-1
```