### PR TITLE
Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,54 +131,54 @@ Test configuration:
 
 First numbers show the difference in creating a template between using `lit-html` directly, doing same via `carehtml` wrapper, and most importantly, using Custom Element classes in place of tag names.
 
-| create template for lit-html            |      ops/sec |
-| --------------------------------------- | -----------: |
-| Chrome 79.0.3945                        |              |
-| clean html\`\<el-name>\</el-name>\`     |  `149575145` |
-| care(html)\`\<el-name>\</el-name>\`     |   `30728712` |
-| care(html)\`<${ElClass}></${ElClass}>\` |    `4654638` |
-| Firefox 71.0.0                          |              |
-| clean html\`\<el-name>\</el-name>\`     | `1268411403` |
-| care(html)\`\<el-name>\</el-name>\`     |    `7112878` |
-| care(html)\`<${ElClass}></${ElClass}>\` |    `1551298` |
-| Safari 13.0.3                           |              |
-| clean html\`\<el-name>\</el-name>\`     |   `29071424` |
-| care(html)\`\<el-name>\</el-name>\`     |    `7572036` |
-| care(html)\`<${ElClass}></${ElClass}>\` |    `1800394` |
+| create template for lit-html            | without cache (ops/sec) | with cache (ops/sec) |  diff |
+| --------------------------------------- | ----------------------: | -------------------: | ----: |
+| Chrome 79.0.3945                        |                         |                      |       |
+| clean html\`\<el-name>\</el-name>\`     |             `149575145` |                      |       |
+| care(html)\`\<el-name>\</el-name>\`     |              `30728712` |                      |       |
+| care(html)\`<${ElClass}></${ElClass}>\` |               `4654638` |            `1343314` | x0.29 |
+| Firefox 71.0.0                          |                         |                      |       |
+| clean html\`\<el-name>\</el-name>\`     |            `1268411403` |                      |       |
+| care(html)\`\<el-name>\</el-name>\`     |               `7112878` |                      |       |
+| care(html)\`<${ElClass}></${ElClass}>\` |               `1551298` |             `982065` | x0.63 |
+| Safari 13.0.3                           |                         |                      |       |
+| clean html\`\<el-name>\</el-name>\`     |              `29071424` |                      |       |
+| care(html)\`\<el-name>\</el-name>\`     |               `7572036` |                      |       |
+| care(html)\`<${ElClass}></${ElClass}>\` |               `1800394` |            `1139581` | x0.63 |
 
 Next numbers show the rendering times of those from above.
 
-| render template for lit-html            |    ops/sec |
-| --------------------------------------- | ---------: |
-| Chrome 79.0.3945                        |            |
-| clean html\`\<el-name>\</el-name>\`     | `20270378` |
-| care(html)\`\<el-name>\</el-name>\`     | `20915893` |
-| care(html)\`<${ElClass}></${ElClass}>\` | `20682304` |
-| Firefox 71.0.0                          |            |
-| clean html\`\<el-name>\</el-name>\`     |  `3252965` |
-| care(html)\`\<el-name>\</el-name>\`     |  `3418368` |
-| care(html)\`<${ElClass}></${ElClass}>\` |  `3228236` |
-| Safari 13.0.3                           |            |
-| clean html\`\<el-name>\</el-name>\`     | `10930284` |
-| care(html)\`\<el-name>\</el-name>\`     | `10873434` |
-| care(html)\`<${ElClass}></${ElClass}>\` | `10822978` |
+| render template for lit-html            | without cache (ops/sec) | with cache (ops/sec) | diff |
+| --------------------------------------- | ----------------------: | -------------------: | ---: |
+| Chrome 79.0.3945                        |                         |                      |      |
+| clean html\`\<el-name>\</el-name>\`     |              `20270378` |                      |      |
+| care(html)\`\<el-name>\</el-name>\`     |              `20915893` |                      |      |
+| care(html)\`<${ElClass}></${ElClass}>\` |              `20682304` |           `22036696` |  ~x0 |
+| Firefox 71.0.0                          |                         |                      |      |
+| clean html\`\<el-name>\</el-name>\`     |               `3252965` |                      |      |
+| care(html)\`\<el-name>\</el-name>\`     |               `3418368` |                      |      |
+| care(html)\`<${ElClass}></${ElClass}>\` |               `3228236` |            `3310977` |  ~x0 |
+| Safari 13.0.3                           |                         |                      |      |
+| clean html\`\<el-name>\</el-name>\`     |              `10930284` |                      |      |
+| care(html)\`\<el-name>\</el-name>\`     |              `10873434` |                      |      |
+| care(html)\`<${ElClass}></${ElClass}>\` |              `10822978` |            `9544333` |  ~x0 |
 
 Next numbers show the combination of both.
 
-| create and render template for lit-html |    ops/sec |
-| --------------------------------------- | ---------: |
-| Chrome 79.0.3945                        |            |
-| clean html\`\<el-name>\</el-name>\`     | `13208368` |
-| care(html)\`\<el-name>\</el-name>\`     |  `8984663` |
-| care(html)\`<${ElClass}></${ElClass}>\` |   `559925` |
-| Firefox 71.0.0                          |            |
-| clean html\`\<el-name>\</el-name>\`     |  `3237455` |
-| care(html)\`\<el-name>\</el-name>\`     |  `2107983` |
-| care(html)\`<${ElClass}></${ElClass}>\` |   `279335` |
-| Safari 13.0.3                           |            |
-| clean html\`\<el-name>\</el-name>\`     |  `8824180` |
-| care(html)\`\<el-name>\</el-name>\`     |  `5019988` |
-| care(html)\`<${ElClass}></${ElClass}>\` |   `777846` |
+| create and render template for lit-html | without cache (ops/sec) | with cache (ops/sec) |  diff |
+| --------------------------------------- | ----------------------: | -------------------: | ----: |
+| Chrome 79.0.3945                        |                         |                      |       |
+| clean html\`\<el-name>\</el-name>\`     |              `13208368` |                      |       |
+| care(html)\`\<el-name>\</el-name>\`     |               `8984663` |                      |       |
+| care(html)\`<${ElClass}></${ElClass}>\` |                `559925` |             `861831` | x1.54 |
+| Firefox 71.0.0                          |                         |                      |       |
+| clean html\`\<el-name>\</el-name>\`     |               `3237455` |                      |       |
+| care(html)\`\<el-name>\</el-name>\`     |               `2107983` |                      |       |
+| care(html)\`<${ElClass}></${ElClass}>\` |                `279335` |             `584330` | x2.09 |
+| Safari 13.0.3                           |                         |                      |       |
+| clean html\`\<el-name>\</el-name>\`     |               `8824180` |                      |       |
+| care(html)\`\<el-name>\</el-name>\`     |               `5019988` |                      |       |
+| care(html)\`<${ElClass}></${ElClass}>\` |                `777846` |             `838853` |   ~x0 |
 
 ## Special Thanks
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,4 +1,7 @@
 const registeredElements = new Map();
+const cache1 = [];
+const cache2 = new Map();
+const CACHE2_SEPARATOR = '$$carehtml_separator$$';
 
 function toDashCase(name) {
   const dashCaseLetters = [];
@@ -75,5 +78,19 @@ export default function transform(strings, values) {
     newStrings.push(strings[strings.length - 1]);
   }
   result[0] = newStrings;
+
+  if (cache1.indexOf(strings) !== -1) {
+    const cache2key = newStrings.join(CACHE2_SEPARATOR);
+    const cachedStrings = cache2.get(cache2key);
+    if (cachedStrings) {
+      result[0] = cachedStrings;
+    } else {
+      cache2.set(cache2key, newStrings);
+    }
+  } else {
+    cache1.push(strings);
+    cache2.set(newStrings.join(CACHE2_SEPARATOR), newStrings);
+  }
+
   return result;
 }

--- a/test/wrap.spec.js
+++ b/test/wrap.spec.js
@@ -16,6 +16,18 @@ describe('wrap', () => {
     expect(calledArgs).to.deep.equal([['<my-lily id="', '">', '</my-lily>'], 'my-id', 'my text']);
   });
 
+  it('returns same array reference for caching in html literal implementation', () => {
+    const calledArgs = [];
+    const html = wrap((...args) => {
+      calledArgs.push(args);
+    });
+    class MyZinnia extends HTMLElement {}
+    const render = () => html`<${MyZinnia} id="${'my-id'}">${'my text'}</${MyZinnia}>`;
+    render();
+    render();
+    expect(calledArgs[0][0]).to.equal(calledArgs[1][0]);
+  });
+
   it('integrates with lit-html', async () => {
     const { html: litHtml, TemplateResult, render } = await import('lit-html');
 


### PR DESCRIPTION
Implemented cache to prevent rerendering when template's strings reference change on each call of the tag function. This happened because we didn't take into account that it is important for lit-html to preserve the same strings reference across calls of the tag function to optimize rendering (basically reuse existing TemplateResult and skip rendering if values don't change).

Numbers show that there is some improvement of rendering in Chrome (~1.5 times faster) and Firefox (~2 times faster). In Safari there is nearly no difference, and this is expected, because `lit-html` implement similar cache internally to work around Safari bug with tagged template literals.