### PR TITLE
fix(transform): do not throw on nullish value

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -54,7 +54,7 @@ export default function transform(strings, values) {
   let mergeWithLastString = false;
   values.forEach((value, index) => {
     const string = strings[index];
-    if (value.prototype instanceof HTMLElement) {
+    if (value && value.prototype instanceof HTMLElement) {
       const tag = getClassUniqueTag(value);
       if (mergeWithLastString) {
         const lastString = newStrings[newStrings.length - 1];

--- a/test/transform.spec.js
+++ b/test/transform.spec.js
@@ -13,6 +13,14 @@ describe('transform', () => {
     expect(customElements.get('my-tulip')).to.equal(MyTulip);
   });
 
+  it('does not throw on nullish values', () => {
+    class MyHops extends HTMLElement {}
+    expect(transform(...testhtml`<${MyHops} attribute=${null}></${MyHops}>`)).to.not.throw;
+    expect(transform(...testhtml`<${MyHops} attribute=${undefined}></${MyHops}>`)).to.not.throw;
+    expect(transform(...testhtml`<${MyHops}>${null}</${MyHops}>`)).to.not.throw;
+    expect(transform(...testhtml`<${MyHops}>${undefined}</${MyHops}>`)).to.not.throw;
+  });
+
   describe('concatenation', () => {
     it('concatenates element names with no other expressions', () => {
       class MyViolet extends HTMLElement {}

--- a/test/wrap.spec.js
+++ b/test/wrap.spec.js
@@ -11,9 +11,10 @@ describe('wrap', () => {
     });
     class MyLily extends HTMLElement {}
 
-    html`<${MyLily} id="${'my-id'}">${'my text'}</${MyLily}>`;
+    html`<${MyLily} id="${'my-id'}" style=${null}>${'my text'}</${MyLily}>`;
+    console.warn(calledArgs);
     expect(calledCount).to.equal(1);
-    expect(calledArgs).to.deep.equal([['<my-lily id="', '">', '</my-lily>'], 'my-id', 'my text']);
+    expect(calledArgs).to.deep.equal([['<my-lily id="', '" style=', '>', '</my-lily>'], 'my-id', null, 'my text']);
   });
 
   it('integrates with lit-html', async () => {

--- a/test/wrap.spec.js
+++ b/test/wrap.spec.js
@@ -11,10 +11,9 @@ describe('wrap', () => {
     });
     class MyLily extends HTMLElement {}
 
-    html`<${MyLily} id="${'my-id'}" style=${null}>${'my text'}</${MyLily}>`;
-    console.warn(calledArgs);
+    html`<${MyLily} id="${'my-id'}">${'my text'}</${MyLily}>`;
     expect(calledCount).to.equal(1);
-    expect(calledArgs).to.deep.equal([['<my-lily id="', '" style=', '>', '</my-lily>'], 'my-id', null, 'my text']);
+    expect(calledArgs).to.deep.equal([['<my-lily id="', '">', '</my-lily>'], 'my-id', 'my text']);
   });
 
   it('integrates with lit-html', async () => {


### PR DESCRIPTION
This closes #18 by checking for a falsey `value` in `transform` before checking `value.prototype instanceof HTMLElement`, thereby also excluding nullish values. Since no `HTMLElement` is ever falsey, this will never exclude a needed value by mistake.