### PR TITLE
Handle null value

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -54,7 +54,7 @@ export default function transform(strings, values) {
   let mergeWithLastString = false;
   values.forEach((value, index) => {
     const string = strings[index];
-    if (value.prototype instanceof HTMLElement) {
+    if ((typeof value === 'function') && value.prototype instanceof HTMLElement) {
       const tag = getClassUniqueTag(value);
       if (mergeWithLastString) {
         const lastString = newStrings[newStrings.length - 1];


### PR DESCRIPTION
Values inside a template string can be null or undefined.

This change prevents `TypeError: Cannot read property 'prototype' of null` in such cases.