### PR TITLE
Fix tests in Edge

### DIFF
--- a/benchmarks/template-tachometer.json
+++ b/benchmarks/template-tachometer.json
@@ -11,6 +11,12 @@
           "entryName": "{{measurement}}"
         }
       ],
+      "packageVersions": {
+        "label": "lit-html-without-template-string-cache",
+        "dependencies": {
+          "lit-html": "2.0.0-pre.7"
+        }
+      },
       "expand": [
         {
           "name": "direct",

--- a/benchmarks/template-tachometer.json
+++ b/benchmarks/template-tachometer.json
@@ -4,35 +4,25 @@
   "timeout": 0,
   "benchmarks": [
     {
-      "name": "direct",
-      "url": "benchmarks/index.html?direct",
       "browser": "{{browser}}",
       "measurement": [
         {
           "mode": "performance",
           "entryName": "{{measurement}}"
         }
-      ]
-    },
-    {
-      "name": "wrapped",
-      "url": "benchmarks/index.html?wrapped",
-      "browser": "{{browser}}",
-      "measurement": [
+      ],
+      "expand": [
         {
-          "mode": "performance",
-          "entryName": "{{measurement}}"
-        }
-      ]
-    },
-    {
-      "name": "wrapped with classes",
-      "url": "benchmarks/index.html?wrapped-with-classes",
-      "browser": "{{browser}}",
-      "measurement": [
+          "name": "direct",
+          "url": "benchmarks/index.html?direct"
+        },
         {
-          "mode": "performance",
-          "entryName": "{{measurement}}"
+          "name": "wrapped",
+          "url": "benchmarks/index.html?wrapped"
+        },
+        {
+          "name": "wrapped with classes",
+          "url": "benchmarks/index.html?wrapped-with-classes"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "htm": "^3.0.4",
     "husky": "^6.0.0",
     "lint-staged": "^10.5.4",
-    "lit-html": "2.0.0-pre.7",
+    "lit-html": "1.3.0",
     "preact": "^10.5.13",
     "prettier": "^2.2.1",
     "tachometer": "^0.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5490,10 +5490,10 @@ listr2@^3.2.2:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-html@2.0.0-pre.7:
-  version "2.0.0-pre.7"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0-pre.7.tgz#499fa78a0119bb4f4398944f6bebf1b265ced914"
-  integrity sha512-qy/fHSRzf7cCbXGLXVBRwecnLgioyvkKbk4WGVswbelK6OD5tqhwY2wVWclEA0JEuNkGQW81ad15BeGxR46uig==
+lit-html@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
+  integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
 
 load-json-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Due to this issue https://github.com/modernweb-dev/web/issues/1265 the tests in Edge fail on lit-html 2.x integration.
As a workaround we can use lit-html 1.x in unit tests and 2.x in benchmarks.