### PR TITLE
Support Lit 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ There are 2 main reasons Web Components need something like this:
 1. Lack of scoping when registering Custom Elements which creates issues in tests and makes it impossible to have 2 different components with the same name.
 2. Inability to have 2 different versions of the same Custom Element when refactoring from an old to a new version, especially when having nested node modules.
 
-## Usage with lit-html and LitElement
+## Usage with Lit
 
-You need to wrap the lit-html:
+You need to wrap the Lit `html` tag:
 
 ```js
-import { LitElement, html as litHtml } from '@polymer/lit-element';
+import { LitElement, html as litHtml } from 'lit';
 import takeCareOf from 'carehtml';
 
 const html = takeCareOf(litHtml);
@@ -38,8 +38,8 @@ class MySearchBar extends LitElement {
 }
 ```
 
-> Wrapping the lit-html function is extra work which might seem unnecessary in the user code, but that allows to decouple `carehtml` from `lit-html`, primarily in terms of npm dependencies.
-> This allows to use `carehtml` with any version of `lit-html` and develop `carehtml` with its independent release cycle.
+> Wrapping is extra work which might seem unnecessary in the user code, but that allows to decouple `carehtml` from `lit`, primarily in terms of npm dependencies.
+> This allows to use `carehtml` with any version of `lit` and develop `carehtml` with its independent release cycle.
 
 ## Usage with Other Templating Libraries Based on Tagged Templates
 
@@ -81,7 +81,7 @@ render(html`<${App} page="All" />`, document.body);
 ## Usage in Tests
 
 ```js
-import { html as litHtml, render } from 'lit-html';
+import { html as litHtml, render } from 'lit';
 import takeCareOf from 'carehtml';
 
 const html = takeCareOf(litHtml);
@@ -93,7 +93,7 @@ describe('MyMixin', () => {
     }
 
     // create fixture
-    // (html`` in this context returns a lit-html TemplateResult as if it was lit-html itself)
+    // (html`` in this context returns TemplateResult as if it was Lit itself)
     const element = fixture(html`<${MyElement}></${MyElement}>`);
 
     // test mixin/element behavior
@@ -124,20 +124,19 @@ You can play around with this by using `yarn bench:create-and-render:chrome` scr
 
 The only thing that makes sense to measure in this situation is the rerendering.
 The idea is to check if it does not rerender unnecessarily second time when the classes stay the same meaning that the actual template is also the same.
-That's what makes `lit-html` so fast after all and `carehml` should not break this essential optimisation.
+That's what makes Lit so fast after all and `carehml` should not break this essential optimisation.
 In such benchmarks the `<my-element></my-element>` should have an internal template which will take most of the time of each render, so that the rerendering (if it happens) is close to being 2 times slower due to that internal template being rendered again.
 The end setup has `MyElement` with a shadow root with 100000 divs containing some text.
 The script `yarn bench:create-and-render-twice` can be used to measure that.
-The goal is to have the same numbers when using `lit-html` directly or wrapped with `carehtml`.
-And it's important to measure this with `lit-html 2.x` which does not have a special template string cache originally introduced for legacy browsers where string template literals were buggy.
+The goal is to have the same numbers when using Lit `html` directly or wrapped with `carehtml`.
 
 These are the results for Chrome which clearly show no overhead on rerendering when wrapping with `carehtml`:
 
-| Benchmark            |            Avg time |                                vs direct |                               vs wrapped |                  vs wrapped with classes |
-| -------------------- | ------------------: | ---------------------------------------: | ---------------------------------------: | ---------------------------------------: |
-| direct               | 108.63ms - 112.34ms |                                        - | unsure<br>-1% - +3%<br>-1.57ms - +2.84ms | unsure<br>-2% - +2%<br>-2.42ms - +1.80ms |
-| wrapped              | 108.66ms - 111.05ms | unsure<br>-3% - +1%<br>-2.84ms - +1.57ms |                                        - | unsure<br>-2% - +1%<br>-2.51ms - +0.61ms |
-| wrapped with classes | 109.80ms - 111.80ms | unsure<br>-2% - +2%<br>-1.80ms - +2.42ms | unsure<br>-1% - +2%<br>-0.61ms - +2.51ms |                                        - |
+| Benchmark            |          Avg time |                                vs direct |                               vs wrapped |                  vs wrapped with classes |
+| -------------------- | ----------------: | ---------------------------------------: | ---------------------------------------: | ---------------------------------------: |
+| direct               | 52.30ms - 53.12ms |                                        - | unsure<br>-2% - +1%<br>-0.99ms - +0.44ms | unsure<br>-2% - +0%<br>-1.08ms - +0.04ms |
+| wrapped              | 52.40ms - 53.57ms | unsure<br>-1% - +2%<br>-0.44ms - +0.99ms |                                        - | unsure<br>-2% - +1%<br>-0.94ms - +0.46ms |
+| wrapped with classes | 52.85ms - 53.61ms | unsure<br>-0% - +2%<br>-0.04ms - +1.08ms | unsure<br>-1% - +2%<br>-0.46ms - +0.94ms |                                        - |
 
 Measurements in other browsers are similar.
 

--- a/benchmarks/index.html
+++ b/benchmarks/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <script type="module">
-  import { html as litHtml, render } from 'lit-html';
+  import { html as litHtml, render } from 'lit';
   import wrap from '../src/wrap.js';
 
   const queryParams = new URL(document.location).searchParams;

--- a/benchmarks/template-tachometer.json
+++ b/benchmarks/template-tachometer.json
@@ -11,12 +11,6 @@
           "entryName": "{{measurement}}"
         }
       ],
-      "packageVersions": {
-        "label": "lit-html-without-template-string-cache",
-        "dependencies": {
-          "lit-html": "2.0.0-pre.7"
-        }
-      },
       "expand": [
         {
           "name": "direct",

--- a/benchmarks/template-tachometer.json
+++ b/benchmarks/template-tachometer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/Polymer/tachometer/v0.5.8/config.schema.json",
+  "$schema": "https://raw.githubusercontent.com/Polymer/tachometer/v0.5.10/config.schema.json",
   "sampleSize": 30,
   "timeout": 0,
   "benchmarks": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "htm": "^3.0.4",
     "husky": "^6.0.0",
     "lint-staged": "^10.5.4",
-    "lit-html": "1.3.0",
+    "lit": "^2.2.2",
     "preact": "^10.5.13",
     "prettier": "^2.2.1",
     "tachometer": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lit-html": "1.3.0",
     "preact": "^10.5.13",
     "prettier": "^2.2.1",
-    "tachometer": "^0.5.8",
+    "tachometer": "^0.5.10",
     "wallaby-webpack": "^3.9.16",
     "webpack": "^4.46.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@bundled-es-modules/chai": "^4.2.2",
     "@commitlint/cli": "^12.1.1",
     "@commitlint/config-conventional": "^12.1.1",
+    "@ungap/global-this": "^0.4.4",
     "@web/dev-server-legacy": "^1.0.0",
     "@web/test-runner": "^0.13.27",
     "@web/test-runner-browserstack": "^0.5.0",

--- a/src/transform.js
+++ b/src/transform.js
@@ -52,22 +52,28 @@ export default function transform(strings, values) {
     return [strings];
   }
   const newStrings = [];
+  newStrings.raw = [];
   const result = [0]; // first index is reserved for strings
   let mergeWithLastString = false;
   values.forEach((value, index) => {
     const string = strings[index];
+    const stringRaw = strings.raw[index];
     if (value && value.prototype instanceof HTMLElement) {
       const tag = getClassUniqueTag(value);
       if (mergeWithLastString) {
         const lastString = newStrings[newStrings.length - 1];
+        const lastStringRaw = newStrings.raw[newStrings.raw.length - 1];
         newStrings[newStrings.length - 1] = `${lastString}${tag}${strings[index + 1]}`;
+        newStrings.raw[newStrings.raw.length - 1] = String.raw`${lastStringRaw}${tag}${strings.raw[index + 1]}`;
       } else {
         newStrings.push(`${string}${tag}${strings[index + 1]}`);
+        newStrings.raw.push(String.raw`${stringRaw}${tag}${strings.raw[index + 1]}`);
       }
       mergeWithLastString = true;
     } else {
       if (!mergeWithLastString) {
         newStrings.push(string);
+        newStrings.raw.push(stringRaw);
       }
       result.push(value);
       mergeWithLastString = false;
@@ -75,6 +81,7 @@ export default function transform(strings, values) {
   });
   if (!mergeWithLastString) {
     newStrings.push(strings[strings.length - 1]);
+    newStrings.raw.push(strings.raw[strings.raw.length - 1]);
   }
 
   const cacheKey = newStrings.join(CACHE_SEPARATOR);

--- a/src/transform.spec.js
+++ b/src/transform.spec.js
@@ -2,13 +2,18 @@ import { expect } from '@bundled-es-modules/chai';
 import transform from './transform.js';
 
 const testhtml = (strings, ...values) => [strings, values];
-const getNameForCEClass = (klass) => transform(['', ''], [klass])[0][0];
+const getNameForCEClass = (klass) => {
+  const strings = ['', ''];
+  strings.raw = ['', ''];
+  return transform(strings, [klass])[0][0];
+};
 
 describe('transform', () => {
   it('registers names for Custom Element classes in values and concatenates strings with those names', () => {
     class MyTulip extends HTMLElement {}
     const [strings, ...values] = transform(...testhtml`<${MyTulip} id="${'my-id'}">${'my text'}</${MyTulip}>`);
     expect(strings).to.deep.equal(['<my-tulip id="', '">', '</my-tulip>']);
+    expect(strings.raw).to.deep.equal(['<my-tulip id="', '">', '</my-tulip>']);
     expect(values).to.deep.equal(['my-id', 'my text']);
     expect(customElements.get('my-tulip')).to.equal(MyTulip);
   });
@@ -26,6 +31,7 @@ describe('transform', () => {
       class MyViolet extends HTMLElement {}
       const [strings, ...values] = transform(...testhtml`<${MyViolet}></${MyViolet}>`);
       expect(strings).to.deep.equal(['<my-violet></my-violet>']);
+      expect(strings.raw).to.deep.equal(['<my-violet></my-violet>']);
       expect(values).to.deep.equal([]);
       expect(customElements.get('my-violet')).to.equal(MyViolet);
     });
@@ -34,10 +40,12 @@ describe('transform', () => {
       class MyDaisy extends HTMLElement {}
       const [strings, ...values] = transform(...testhtml`<${MyDaisy}>${'my text'}</${MyDaisy}>`);
       expect(strings).to.deep.equal(['<my-daisy>', '</my-daisy>']);
+      expect(strings.raw).to.deep.equal(['<my-daisy>', '</my-daisy>']);
       expect(values).to.deep.equal(['my text']);
       expect(customElements.get('my-daisy')).to.equal(MyDaisy);
       const [strings2, ...values2] = transform(...testhtml`<${MyDaisy}>my text</${MyDaisy}>`);
       expect(strings2).to.deep.equal(['<my-daisy>my text</my-daisy>']);
+      expect(strings2.raw).to.deep.equal(['<my-daisy>my text</my-daisy>']);
       expect(values2).to.deep.equal([]);
     });
 
@@ -45,10 +53,12 @@ describe('transform', () => {
       class MySunflower extends HTMLElement {}
       const [strings, ...values] = transform(...testhtml`<${MySunflower} id="${'my-id'}"></${MySunflower}>`);
       expect(strings).to.deep.equal(['<my-sunflower id="', '"></my-sunflower>']);
+      expect(strings.raw).to.deep.equal(['<my-sunflower id="', '"></my-sunflower>']);
       expect(values).to.deep.equal(['my-id']);
       expect(customElements.get('my-sunflower')).to.equal(MySunflower);
       const [strings2, ...values2] = transform(...testhtml`<${MySunflower} id="my-id"></${MySunflower}>`);
       expect(strings2).to.deep.equal(['<my-sunflower id="my-id"></my-sunflower>']);
+      expect(strings2.raw).to.deep.equal(['<my-sunflower id="my-id"></my-sunflower>']);
       expect(values2).to.deep.equal([]);
     });
 
@@ -56,6 +66,7 @@ describe('transform', () => {
       class MyRose extends HTMLElement {}
       const [strings, ...values] = transform(...testhtml`<my-rose></my-rose>`);
       expect(strings).to.deep.equal(['<my-rose></my-rose>']);
+      expect(strings.raw).to.deep.equal(['<my-rose></my-rose>']);
       expect(values).to.deep.equal([]);
       expect(customElements.get('my-rose')).to.not.equal(MyRose);
     });
@@ -64,10 +75,12 @@ describe('transform', () => {
       class MyMagnolia {}
       const [strings, ...values] = transform(...testhtml`<${MyMagnolia}></${MyMagnolia}>`);
       expect(strings).to.deep.equal(['<', '></', '>']);
+      expect(strings.raw).to.deep.equal(['<', '></', '>']);
       expect(values).to.deep.equal([MyMagnolia, MyMagnolia]);
       expect(customElements.get('my-magnolia')).to.not.exist;
       const [strings2, ...values2] = transform(...testhtml`<${MyMagnolia}/>`);
       expect(strings2).to.deep.equal(['<', '/>']);
+      expect(strings2.raw).to.deep.equal(['<', '/>']);
       expect(values2).to.deep.equal([MyMagnolia]);
     });
   });

--- a/src/wrap.spec.js
+++ b/src/wrap.spec.js
@@ -1,3 +1,4 @@
+import '@ungap/global-this';
 import { expect } from '@bundled-es-modules/chai';
 import wrap from './wrap.js';
 

--- a/src/wrap.spec.js
+++ b/src/wrap.spec.js
@@ -29,8 +29,8 @@ describe('wrap', () => {
     expect(calledArgs[0][0]).to.equal(calledArgs[1][0]);
   });
 
-  it('integrates with lit-html', async () => {
-    const { html: litHtml, render } = await import('lit-html');
+  it('integrates with lit', async () => {
+    const { html: litHtml, render } = await import('lit');
 
     const html = wrap(litHtml);
     class MyAzalea extends HTMLElement {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,6 +1003,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@lit/reactive-element@^1.3.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.3.1.tgz#3021ad0fa30a75a41212c5e7f1f169c5762ef8bb"
+  integrity sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw==
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -1343,6 +1348,11 @@
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@types/table/-/table-6.0.0.tgz#c3e8f1e0d80525036a7655fd650409e0230f1ead"
   integrity sha512-RSmRiYetRzpcZcgNo4x6C1VSsPGBHCGGDO7Rbnz5esVLbGONxBP1CUcn8JhAkVzUVLO+AY8yOSkb27jvfauLyg==
+
+"@types/trusted-types@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
+  integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
 "@types/ua-parser-js@^0.7.33":
   version "0.7.36"
@@ -5767,10 +5777,29 @@ listr2@^3.2.2:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-html@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
-  integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
+lit-element@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.2.0.tgz#9c981c55dfd9a8f124dc863edb62cc529d434db7"
+  integrity sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==
+  dependencies:
+    "@lit/reactive-element" "^1.3.0"
+    lit-html "^2.2.0"
+
+lit-html@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.2.2.tgz#06ced65dd3fb2d7a214d998c65acc576ae2cb3c4"
+  integrity sha512-cJofCRXuizwyaiGt9pJjJOcauezUlSB6t87VBXsPwRhbzF29MgD8GH6fZ0BuZdXAAC02IRONZBd//VPUuU8QbQ==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+
+lit@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.2.2.tgz#b7f729d6ca7e17efbf2bf589df2d5eb04d9620ba"
+  integrity sha512-eN3+2QRHn/erxYB88AXiiRgQA6RltE9MhzySCwX+ACOxA/MLWN3VdXvcbZD9PN09zmUwlgzDvW3T84YWj2Sa0A==
+  dependencies:
+    "@lit/reactive-element" "^1.3.0"
+    lit-element "^3.2.0"
+    lit-html "^2.2.0"
 
 load-json-file@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,6 +1368,11 @@
   dependencies:
     "@types/node" "*"
 
+"@ungap/global-this@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@ungap/global-this/-/global-this-0.4.4.tgz#8a1b2cfcd3e26e079a847daba879308c924dd695"
+  integrity sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==
+
 "@wdio/config@7.19.5":
   version "7.19.5"
   resolved "https://registry.yarnpkg.com/@wdio/config/-/config-7.19.5.tgz#aa8158d648e1ffb28a7e53474d5ce171066e82f7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1971,12 +1971,12 @@ ansi-cyan@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-escape-sequences@^5.0.0:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz#b24471db2073009ebe28a7044ac7436bbd3d28e7"
-  integrity sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==
+ansi-escape-sequences@^6.0.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-escape-sequences/-/ansi-escape-sequences-6.2.1.tgz#6127d70b55f6f49af8b6f8968921ce9a39f1f2ad"
+  integrity sha512-0gK95MrLXv+Vy5h4eKGvSX1yXopBqSYBi3/w4hekUxs/hHakF6asH9Gg7UXbb7IH9weAlVIrUzVOITNBr8Imag==
   dependencies:
-    array-back "^4.0.0"
+    array-back "^6.2.2"
 
 ansi-escapes@^3.1.0:
   version "3.2.0"
@@ -2150,10 +2150,15 @@ array-back@^3.0.1:
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
   integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
 
-array-back@^4.0.0, array-back@^4.0.1:
+array-back@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.1.tgz#9b80312935a52062e1a233a9c7abeb5481b30e90"
   integrity sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==
+
+array-back@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
+  integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
 
 array-differ@^1.0.0:
   version "1.0.0"
@@ -4358,7 +4363,7 @@ fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1:
+fs-extra@^9.0.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -5450,10 +5455,10 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonschema@~1.2.11:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.11.tgz#7a799cc2aa5a285d893203e8dc81f5becbfb0e91"
-  integrity sha512-XNZHs3N1IOa3lPKm//npxMhOdaoPw+MvEV0NIgxcER83GTJcG13rehtWmpBCfEt8DrtYwIkMTs8bdXoYs4fvnQ==
+jsonschema@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
+  integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
 
 jsonwebtoken@^8.5.1:
   version "8.5.1"
@@ -8202,22 +8207,22 @@ table@^6.0.4, table@^6.0.7:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
-tachometer@^0.5.8:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/tachometer/-/tachometer-0.5.8.tgz#7679a1e0334be360e8fc7229004a04f6899a94d3"
-  integrity sha512-CttguFunKN/qlK2HXwzbEDGPOVCIKjTTKVzGyR3evV0/IimSryOeNgWOZzvVkURKlg86znsOHn+Ne2DHgknp6A==
+tachometer@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/tachometer/-/tachometer-0.5.10.tgz#1c158fa0e1a54aeeee69c603f866c649a11ddf77"
+  integrity sha512-2FbP+uA4Pcx0IbcfKP15IXhqueq73E5U1NWOsD9m3j5mtHqMSMtNXDJ1CpegZcDuYd2Dg+L2Nu3+e40Q+X8t7w==
   dependencies:
     "@types/command-line-usage" "^5.0.1"
     "@types/selenium-webdriver" "^4.0.11"
     "@types/table" "^6.0.0"
-    ansi-escape-sequences "^5.0.0"
+    ansi-escape-sequences "^6.0.1"
     command-line-args "^5.0.2"
     command-line-usage "^6.1.0"
     csv-stringify "^5.3.0"
-    fs-extra "^9.0.1"
+    fs-extra "^10.0.0"
     get-stream "^6.0.0"
     got "^11.5.0"
-    jsonschema "~1.2.11"
+    jsonschema "^1.4.0"
     jsonwebtoken "^8.5.1"
     jstat "^1.9.2"
     koa "^2.11.0"


### PR DESCRIPTION
Primarily fixes `strings.raw` error from Lit

```
Internal Error: expected template strings to be an array
with a 'raw' field. Faking a template strings array by
calling html or svg like an ordinary function is effectively
the same as calling unsafeHtml and can lead to major security
issues, e.g. opening your code up to XSS attacks.

If you're using the html or svg tagged template functions normally
and and still seeing this error, please file a bug at
https://github.com/lit/lit/issues/new?template=bug_report.md
and include information about your build tooling, if any.
```

About

> can lead to major security issues, e.g. opening your code up to XSS attacks

`carehtml` doesn't modify the strings except the class -> name translation which is the core feature of it. It checks if class is actually an instance of `HTMLElement`, and only does the translation for such classes ignoring anything else (covered by an automated test). The translation does't introduce any special symbols, only `-` and alphabetical chars which in the context shouldn't do harm. Security wise it's a safe approach and shouldn't open code to XSS attacks. Feel free to open issues and send automated tests which prove the opposite.